### PR TITLE
Add annotation support for record fields

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -247,7 +247,6 @@ public final class TypeSpec {
 
           // Record constructor
           boolean firstParameter = true;
-          boolean hasAnnotations = false; // We check for annotations in case we need to unindent later
           codeWriter.emit("(");
           int fieldSpecsLength = fieldSpecs.size();
           for (int i = 0; i < fieldSpecsLength; i++) {
@@ -256,24 +255,11 @@ public final class TypeSpec {
             if (fieldSpec.hasModifier(Modifier.STATIC))
               continue;
             ParameterSpec parameter = ParameterSpec.builder(fieldSpec.type, fieldSpec.name).build();
-            hasAnnotations = !fieldSpec.annotations.isEmpty();
             if (!firstParameter)
               codeWriter.emit(",").emitWrappingSpace();
-
-            if (hasAnnotations) {
-              if (firstParameter) {
-                codeWriter.emit("\n").indent(2);
-              } else {
-                codeWriter.emit("\n\n");
-              }
-              codeWriter.emitAnnotations(fieldSpec.annotations, false);
-            }
-
+            codeWriter.emitAnnotations(fieldSpec.annotations, true);
             parameter.emit(codeWriter, !(i < fieldSpecsLength));
             firstParameter = false;
-          }
-          if (hasAnnotations) {
-            codeWriter.unindent(2).emit("\n");
           }
           codeWriter.emit(")");
         } else {

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -247,6 +247,7 @@ public final class TypeSpec {
 
           // Record constructor
           boolean firstParameter = true;
+          boolean hasAnnotations = false; // We check for annotations in case we need to unindent later
           codeWriter.emit("(");
           int fieldSpecsLength = fieldSpecs.size();
           for (int i = 0; i < fieldSpecsLength; i++) {
@@ -255,10 +256,24 @@ public final class TypeSpec {
             if (fieldSpec.hasModifier(Modifier.STATIC))
               continue;
             ParameterSpec parameter = ParameterSpec.builder(fieldSpec.type, fieldSpec.name).build();
+            hasAnnotations = !fieldSpec.annotations.isEmpty();
             if (!firstParameter)
               codeWriter.emit(",").emitWrappingSpace();
+
+            if (hasAnnotations) {
+              if (firstParameter) {
+                codeWriter.emit("\n").indent(2);
+              } else {
+                codeWriter.emit("\n\n");
+              }
+              codeWriter.emitAnnotations(fieldSpec.annotations, false);
+            }
+
             parameter.emit(codeWriter, !(i < fieldSpecsLength));
             firstParameter = false;
+          }
+          if (hasAnnotations) {
+            codeWriter.unindent(2).emit("\n");
           }
           codeWriter.emit(")");
         } else {

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+
+import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -303,6 +305,26 @@ public final class JavaFileTest {
               .skipJavaLangImports(true).build().toString();
       assertThat(source).isEqualTo("" + "package com.squareup.tacos;\n" + "\n"
               + "record Taco(String name, Integer code) {\n" + "}\n" + "");
+  }
+
+  @Test
+  public void recordTwoAnnotatedFields() {
+    AnnotationSpec annotationSpec = AnnotationSpec.builder(ClassName.get("com.squareup.tacos", "Spicy")).build();
+    String source = JavaFile
+            .builder("com.squareup.tacos",
+                    TypeSpec.recordBuilder("Taco")
+                            .addField(FieldSpec.builder(String.class, "name")
+                                    .addAnnotation(annotationSpec)
+                                    .build())
+                            .addField(FieldSpec.builder(Integer.class, "code")
+                                    .addAnnotation(annotationSpec)
+                                    .build())
+                            .build())
+            .skipJavaLangImports(true).build().toString();
+
+    assertThat(source).isEqualTo("" + "package com.squareup.tacos;\n" + "\n"
+            + "record Taco(\n" + "    @Spicy\n    String name, \n\n"
+            + "    @Spicy\n    Integer code\n" + ") {\n}\n" + "");
   }
 
   @Test public void conflictingImports() throws Exception {

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -320,9 +320,11 @@ public final class JavaFileTest {
                             .build())
             .skipJavaLangImports(true).build().toString();
 
-    assertThat(source).isEqualTo("" + "package com.squareup.tacos;\n" + "\n"
-            + "record Taco(\n" + "    @Spicy\n    String name, \n\n"
-            + "    @Spicy\n    Integer code\n" + ") {\n}\n" + "");
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.tacos;\n"
+            + "\n"
+            + "record Taco(@Spicy String name, @Spicy Integer code) {\n"
+            + "}\n");
   }
 
   @Test public void conflictingImports() throws Exception {

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -26,8 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-
-import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
This PR adds support for annotations inside record fields.

### Example code
```java
AnnotationSpec annotationSpec = AnnotationSpec.builder(ClassName.get("com.squareup.tacos", "Spicy"))
		.build();
JavaFile t = JavaFile
        .builder("com.squareup.tacos",
                TypeSpec.recordBuilder("Taco")
                        .addField(FieldSpec.builder(String.class, "name")
                                .addAnnotation(annotationSpec)
                                .build())
                        .addField(FieldSpec.builder(Integer.class, "code")
                                .addAnnotation(annotationSpec)
                                .build())
                        .build())
        .skipJavaLangImports(true).build();
```

### Result
```java
package com.squareup.tacos;

record Taco(
    @Spicy
    String name, 

    @Spicy
    Integer code
) {
}
```
