### PR TITLE
add support for lambda expressions

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -424,11 +424,14 @@ public final class CodeBlock {
      * to provide specific behaviour such as
      * <b>methodcall((int x, int y) -> x + y, 5)</b>.
      * @param parameters the input parameters of the function.
-     * @param emitTypes true if the types of the inputs should
-     * be emitted on the result.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
      * @param body the body of the function.
      */
-    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes, CodeBlock body) {
+    public Builder addLambda(Iterable<ParameterSpec> parameters, LambdaMode mode, CodeBlock body) {
+      // check for specification of input type visibility
+      boolean emitTypes = mode.equals(LambdaMode.VISIBLE_TYPES);
+
       Stream<ParameterSpec> parameterStream = StreamSupport.stream(
         parameters.spliterator(),
         false
@@ -474,7 +477,7 @@ public final class CodeBlock {
      * @param body the body of the function.
      */
     public Builder addLambda(Iterable<ParameterSpec> parameters, CodeBlock body) {
-        return addLambda(parameters, false, body);
+        return addLambda(parameters, LambdaMode.DEFAULT, body);
     }
 
     /**
@@ -483,16 +486,16 @@ public final class CodeBlock {
      * to provide specific behaviour such as
      * <b>methodcall((int x, int y) -> x + y, 5)</b>.
      * @param parameters the input parameters of the function.
-     * @param emitTypes true if the types of the inputs should
-     * be emitted on the result.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
      * @param expressionFormat the format that should be used
      * for the expression.
      * @param args the values that should be placed in the holders
      * of the format.
      */
-    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes,
+    public Builder addLambda(Iterable<ParameterSpec> parameters, LambdaMode mode,
                              String expressionFormat, Object... args) {
-      return addLambda(parameters, emitTypes, CodeBlock.of(expressionFormat, args));
+      return addLambda(parameters, mode, CodeBlock.of(expressionFormat, args));
     }
 
     /**
@@ -508,7 +511,20 @@ public final class CodeBlock {
      * of the format.
      */
     public Builder addLambda(Iterable<ParameterSpec> parameters, String expressionFormat, Object... args) {
-      return addLambda(parameters, false, CodeBlock.of(expressionFormat, args));
+      return addLambda(parameters, LambdaMode.DEFAULT, CodeBlock.of(expressionFormat, args));
+    }
+
+    /**
+     * Structures a producer lambda function based on a CodeBlock body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
+     * @param body the body of the lambda.
+     */
+    public Builder addLambda(LambdaMode mode, CodeBlock body) {
+      return addLambda(Collections.emptyList(), mode, body);
     }
 
     /**
@@ -519,7 +535,23 @@ public final class CodeBlock {
      * @param body the body of the lambda.
      */
     public Builder addLambda(CodeBlock body) {
-      return addLambda(Collections.emptyList(), false, body);
+      return addLambda(Collections.emptyList(), LambdaMode.DEFAULT, body);
+    }
+
+    /**
+     * Structures a producer lambda function based on an expression body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
+     * @param expressionFormat the format that should be used
+     * for the expression.
+     * @param args the values that should be placed in the holders
+     * of the format.
+     */
+    public Builder addLambda(LambdaMode mode, String expressionFormat, Object... args) {
+      return addLambda(Collections.emptyList(), mode, expressionFormat, args);
     }
 
     /**
@@ -533,7 +565,7 @@ public final class CodeBlock {
      * of the format.
      */
     public Builder addLambda(String expressionFormat, Object... args) {
-      return addLambda(Collections.emptyList(), false, expressionFormat, args);
+      return addLambda(Collections.emptyList(), LambdaMode.DEFAULT, expressionFormat, args);
     }
 
     public Builder indent() {

--- a/src/main/java/com/squareup/javapoet/LambdaMode.java
+++ b/src/main/java/com/squareup/javapoet/LambdaMode.java
@@ -1,0 +1,11 @@
+package com.squareup.javapoet;
+
+/**
+ * The available format modes a lambda function can have.
+ * {@code DEFAULT} example: (x, y) -> x + y;
+ * {@code VISIBLE_TYPES} example: (int x, int y) -> x + y;
+*/
+public enum LambdaMode {
+    DEFAULT,
+    VISIBLE_TYPES
+}

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -296,21 +296,25 @@ public final class MethodSpec {
     private String name;
 
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
-    private TypeName returnType;
-    private final Set<TypeName> exceptions = new LinkedHashSet<>();
-    private final CodeBlock.Builder code = CodeBlock.builder();
-    private boolean varargs;
-    private CodeBlock defaultValue;
-
-    public final List<TypeVariableName> typeVariables = new ArrayList<>();
     public final List<AnnotationSpec> annotations = new ArrayList<>();
     public final List<Modifier> modifiers = new ArrayList<>();
+    public final List<TypeVariableName> typeVariables = new ArrayList<>();
+    private TypeName returnType;
     public final List<ParameterSpec> parameters = new ArrayList<>();
+    private boolean varargs;
+    private final Set<TypeName> exceptions = new LinkedHashSet<>();
+    private final CodeBlock.Builder code = CodeBlock.builder();
+    private CodeBlock defaultValue;
+
 
     private Builder(String name) {
       setName(name);
     }
 
+    /**
+     * Sets a name for this builder.
+     * @param name the name to be set for the method.
+     */
     public Builder setName(String name) {
       checkNotNull(name, "name == null");
       checkArgument(name.equals(CONSTRUCTOR) || SourceVersion.isName(name),
@@ -500,6 +504,10 @@ public final class MethodSpec {
       return nextControlFlow("$L", codeBlock);
     }
 
+    /**
+     * Ends the last open control flow.
+     * Should be used once for every control flow.
+     */
     public Builder endControlFlow() {
       code.endControlFlow();
       return this;
@@ -529,6 +537,98 @@ public final class MethodSpec {
 
     public Builder addStatement(CodeBlock codeBlock) {
       code.addStatement(codeBlock);
+      return this;
+    }
+
+    /**
+     * Structures a lambda function based on some inputs and a CodeBlock body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall((int x, int y) -> x + y, 5)</b>.
+     * @param parameters the input parameters of the function.
+     * @param emitTypes true if the types of the inputs should
+     * be emitted on the result.
+     * @param body the body of the function.
+     */
+    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes, CodeBlock body) {
+      code.addLambda(parameters, emitTypes, body);
+      return this;
+    }
+
+    /**
+     * Structures a lambda function based on some inputs and a CodeBlock body.<br>
+     * Will not emit the input types.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall((x, y) -> x + y, 5)</b>.
+     * @param parameters the input parameters of the function.
+     * @param body the body of the function.
+     */
+    public Builder addLambda(Iterable<ParameterSpec> parameters, CodeBlock body) {
+      code.addLambda(parameters, false, body);
+      return this;
+    }
+
+    /**
+     * Structures a lambda function based on some inputs and an expression body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall((int x, int y) -> x + y, 5)</b>.
+     * @param parameters the input parameters of the function.
+     * @param emitTypes true if the types of the inputs should
+     * be emitted on the result.
+     * @param expressionFormat the format that should be used
+     * for the expression.
+     * @param args the values that should be placed in the holders
+     * of the format.
+     */
+    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes,
+                             String expressionFormat, Object... args) {
+      code.addLambda(parameters, emitTypes, CodeBlock.of(expressionFormat, args));
+      return this;
+    }
+
+    /**
+     * Structures a lambda function based on some inputs and an expression body.<br>
+     * Will not emit the input types.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall((x, y) -> x + y, 5)</b>.
+     * @param parameters the input parameters of the function.
+     * @param expressionFormat the format that should be used
+     * for the expression.
+     * @param args the values that should be placed in the holders
+     * of the format.
+     */
+    public Builder addLambda(Iterable<ParameterSpec> parameters, String expressionFormat, Object... args) {
+      code.addLambda(parameters, false, CodeBlock.of(expressionFormat, args));
+      return this;
+    }
+
+    /**
+     * Structures a producer lambda function based on a CodeBlock body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param body the body of the lambda.
+     */
+    public Builder addLambda(CodeBlock body) {
+      code.addLambda(Collections.emptyList(), false, body);
+      return this;
+    }
+
+    /**
+     * Structures a producer lambda function based on an expression body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param expressionFormat the format that should be used
+     * for the expression.
+     * @param args the values that should be placed in the holders
+     * of the format.
+     */
+    public Builder addLambda(String expressionFormat, Object... args) {
+      code.addLambda(Collections.emptyList(), false, expressionFormat, args);
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -546,12 +546,13 @@ public final class MethodSpec {
      * to provide specific behaviour such as
      * <b>methodcall((int x, int y) -> x + y, 5)</b>.
      * @param parameters the input parameters of the function.
-     * @param emitTypes true if the types of the inputs should
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
      * be emitted on the result.
      * @param body the body of the function.
      */
-    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes, CodeBlock body) {
-      code.addLambda(parameters, emitTypes, body);
+    public Builder addLambda(Iterable<ParameterSpec> parameters, LambdaMode mode, CodeBlock body) {
+      code.addLambda(parameters, mode, body);
       return this;
     }
 
@@ -565,7 +566,7 @@ public final class MethodSpec {
      * @param body the body of the function.
      */
     public Builder addLambda(Iterable<ParameterSpec> parameters, CodeBlock body) {
-      code.addLambda(parameters, false, body);
+      code.addLambda(parameters, LambdaMode.DEFAULT, body);
       return this;
     }
 
@@ -575,16 +576,16 @@ public final class MethodSpec {
      * to provide specific behaviour such as
      * <b>methodcall((int x, int y) -> x + y, 5)</b>.
      * @param parameters the input parameters of the function.
-     * @param emitTypes true if the types of the inputs should
-     * be emitted on the result.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
      * @param expressionFormat the format that should be used
      * for the expression.
      * @param args the values that should be placed in the holders
      * of the format.
      */
-    public Builder addLambda(Iterable<ParameterSpec> parameters, boolean emitTypes,
+    public Builder addLambda(Iterable<ParameterSpec> parameters, LambdaMode mode,
                              String expressionFormat, Object... args) {
-      code.addLambda(parameters, emitTypes, CodeBlock.of(expressionFormat, args));
+      code.addLambda(parameters, mode, CodeBlock.of(expressionFormat, args));
       return this;
     }
 
@@ -601,7 +602,21 @@ public final class MethodSpec {
      * of the format.
      */
     public Builder addLambda(Iterable<ParameterSpec> parameters, String expressionFormat, Object... args) {
-      code.addLambda(parameters, false, CodeBlock.of(expressionFormat, args));
+      code.addLambda(parameters, LambdaMode.DEFAULT, CodeBlock.of(expressionFormat, args));
+      return this;
+    }
+
+    /**
+     * Structures a producer lambda function based on a CodeBlock body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
+     * @param body the body of the lambda.
+     */
+    public Builder addLambda(LambdaMode mode, CodeBlock body) {
+      code.addLambda(Collections.emptyList(), mode, body);
       return this;
     }
 
@@ -613,7 +628,24 @@ public final class MethodSpec {
      * @param body the body of the lambda.
      */
     public Builder addLambda(CodeBlock body) {
-      code.addLambda(Collections.emptyList(), false, body);
+      code.addLambda(Collections.emptyList(), LambdaMode.DEFAULT, body);
+      return this;
+    }
+
+    /**
+     * Structures a producer lambda function based on an expression body.<br>
+     * Should be used with {@link #addCode(String, Object...) addCode},
+     * to provide specific behaviour such as
+     * <b>methodcall(() -> 3 + 2, 5)</b>.
+     * @param mode the format mode that should be used.
+     * @see com.squareup.javapoet.LambdaMode LambdaMode.
+     * @param expressionFormat the format that should be used
+     * for the expression.
+     * @param args the values that should be placed in the holders
+     * of the format.
+     */
+    public Builder addLambda(LambdaMode mode, String expressionFormat, Object... args) {
+      code.addLambda(Collections.emptyList(), mode, expressionFormat, args);
       return this;
     }
 
@@ -628,7 +660,7 @@ public final class MethodSpec {
      * of the format.
      */
     public Builder addLambda(String expressionFormat, Object... args) {
-      code.addLambda(Collections.emptyList(), false, expressionFormat, args);
+      code.addLambda(Collections.emptyList(), LambdaMode.DEFAULT, expressionFormat, args);
       return this;
     }
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -516,7 +516,7 @@ public final class MethodSpecTest {
 
     MethodSpec method = MethodSpec.methodBuilder("method")
     .addCode("methodCall(")
-    .addLambda(List.of(p1, p2), true, body1) // lambda with multiple inputs and (CodeBlock) body
+    .addLambda(List.of(p1, p2), LambdaMode.VISIBLE_TYPES, body1) // lambda with multiple inputs and (CodeBlock) body
     .addCode(", ")
     .addLambda(List.of(p2),
       "$N + $N", "x", "y") // lambda with single input and (String) body
@@ -527,7 +527,7 @@ public final class MethodSpecTest {
     .addCode(", ")
     .addLambda("method1(); method2();") // lambda with multiple statements
     .addCode(", ")
-    .addLambda(List.of(p1), true, "x + 5") // lambda with single input of emitted type
+    .addLambda(List.of(p1), LambdaMode.VISIBLE_TYPES, "x + 5") // lambda with single input of emitted type
     .addCode(");\n")
     .build();
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -574,4 +574,31 @@ public final class MethodSpecTest {
     );
   }
 
+  @Test public void ensureLambdaModeLiability() {
+    // lambda body that does not consider input values
+    CodeBlock body = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");
+
+    CodeBlock codeWithLambda = CodeBlock.builder()
+    .add("methodCall(")
+    .addLambda(LambdaMode.VISIBLE_TYPES, "5 + 3") // ensure that redundant mode specification doesnt break anything
+    .add(");\n")
+    .build();
+
+    MethodSpec method = MethodSpec.methodBuilder("method")
+    .addCode(codeWithLambda)
+    .addCode("Producer<Integer> x = ")
+    .addLambda(LambdaMode.VISIBLE_TYPES, body) // ensure that redundant mode specification doesnt break anything
+    .addCode(";")
+    .build();
+
+    assertThat(method.toString()).isEqualTo(
+      "void method() {\n" +
+        "  methodCall(" +
+          "() -> 5 + 3" +
+        ");\n" +
+        "  Producer<Integer> x = () -> {int x = 3; int y = 5; return x + y;};\n" +
+      "}\n"
+    );
+  }
+
 }


### PR DESCRIPTION
FIRST PART OF ISSUE #5

This feature allows the use of lambda expressions in CodeBlocks and within MethodSpecs.

A usage of the feature can be:

```
// build a method that uses lambdas
MethodSpec method = MethodSpec.methodBuilder("method")
    .addCode("methodCall(")
    .addLambda("5 + 7") // lambda with no inputs and (String) body
    .addCode(", ")
    .addLambda("method1(); method2();") // lambda with multiple statements
    .addCode(");\n")
    .build();
```
**to produce:**
```
void method() {
    methodCall(() -> 5 + 7, () -> {method1(); method2();});
}
```
The visibility of the input types in the result is a conditional that can be configured as follows:
```
// declare the inputs of the function
ParameterSpec p1 = ParameterSpec.builder(TypeName.INT, "x").build();
ParameterSpec p2 = ParameterSpec.builder(TypeName.DOUBLE, "y").build();

...
.addLambda(List.of(p1, p2), true, "5 + 7")
...
```
**that produces**:

```
(int x, double y) -> 5 + 7
```

or:
```
...
addLambda(List.of(p1, p2), "5 + 7")
...
```
**to get**:

```
(x, y) -> 5 + 7
```

It is not required to specify if the body of the lambda is an expression or not when using the feature. The output will reflect, depending on the inputs, the wanted and most importantly, valid, result.

if multiple statements are given as a body to the lambda, in the ouput it will be included in braces.