### PR TITLE
Static changes to the code base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 17
     - name: Build with Maven
-      run: ./mvnw -B package --file pom.xml
+      run: ./mvnw -B verify --file pom.xml

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <module name="SuppressWarningsFilter"/>
+  <module name="FileTabCharacter"/>
+
+  <!-- Trailing spaces -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
+  <!-- Space after 'for' and 'if' -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^\s*(for|if)\b[^ ]"/>
+    <property name="message" value="Space needed before opening parenthesis."/>
+  </module>
+
+  <!-- For each spacing -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^\s*for \(.*?([^ ]:|:[^ ])"/>
+    <property name="message" value="Space needed around ':' character."/>
+  </module>
+
+  <module name="TreeWalker">
+    <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+    <!--module name="JavadocMethod"/-->
+    <!--module name="JavadocType"/-->
+    <!--module name="JavadocVariable"/-->
+    <module name="JavadocStyle"/>
+
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See http://checkstyle.sf.net/config_naming.html -->
+
+    <!-- Checks for imports                              -->
+    <!-- See http://checkstyle.sf.net/config_import.html -->
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
+    <!-- defaults to sun.* packages -->
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="true"/>
+    </module>
+
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+      <property name="max" value="100"/>
+    </module>
+    <module name="MethodLength">
+      <property name="max" value="160"/>
+    </module>
+    <module name="ParameterNumber"/>
+
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="GenericWhitespace"/>
+    <!--<module name="EmptyForIteratorPad"/>-->
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround">
+      <property name="tokens"
+          value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN,
+          COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_CATCH,
+          LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+          LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+          MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST,
+          SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+    </module>
+
+
+    <!-- Modifier Checks                                    -->
+    <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+    <module name="RedundantModifier"/>
+
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See http://checkstyle.sf.net/config_blocks.html -->
+    <module name="AvoidNestedBlocks"/>
+    <!--module name="EmptyBlock"/-->
+    <module name="LeftCurly"/>
+    <!--<module name="NeedBraces"/>-->
+    <module name="RightCurly"/>
+
+
+    <!-- Checks for common coding problems               -->
+    <!-- See http://checkstyle.sf.net/config_coding.html -->
+    <!--module name="AvoidInlineConditionals"/-->
+    <module name="CovariantEquals"/>
+    <module name="EmptyStatement"/>
+    <!--<module name="EqualsAvoidNull"/>-->
+    <module name="EqualsHashCode"/>
+    <!--module name="HiddenField"/-->
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <!--<module name="MagicNumber"/>-->
+    <module name="MissingSwitchDefault"/>
+    <!--module name="RedundantThrows"/-->
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+
+    <!-- Checks for class design                         -->
+    <!-- See http://checkstyle.sf.net/config_design.html -->
+    <!--module name="DesignForExtension"/-->
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <!--module name="VisibilityModifier"/-->
+
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <module name="ArrayTypeStyle"/>
+    <!--module name="FinalParameters"/-->
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+
+    <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
+    <module name="SuppressWarningsHolder"/>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <jimfs-version>1.3.0</jimfs-version>
         <mockito-version>4.11.0</mockito-version>
         <ecj-version>4.6.1</ecj-version>
+        <jacoco-maven-plugin-version>0.8.12</jacoco-maven-plugin-version>
         <compile-testing.version>0.21.0</compile-testing.version>
     </properties>
 
@@ -214,6 +215,53 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <!-- minimum branch coverage should be reached -->
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <!-- all classes must be tested -->
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <mockito-version>4.11.0</mockito-version>
         <ecj-version>4.6.1</ecj-version>
         <jacoco-maven-plugin-version>0.8.12</jacoco-maven-plugin-version>
+        <maven-checkstyle-plugin-version>3.3.1</maven-checkstyle-plugin-version>
         <compile-testing.version>0.21.0</compile-testing.version>
     </properties>
 
@@ -258,6 +259,34 @@
                                 </rule>
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin-version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.18</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <linkXRef>false</linkXRef>
+                    <failsOnError>false</failsOnError>
+                    <configLocation>config/checkstyle/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <consoleOutput>true</consoleOutput>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/src/test/java/ClassNameNoPackageTest.java
+++ b/src/test/java/ClassNameNoPackageTest.java
@@ -23,8 +23,8 @@ import static com.google.common.truth.Truth.assertThat;
  * Since it is impossible to import classes from the default package into other
  * modules, this test must live in this package.
  */
-public final class ClassNameNoPackageTest
-{
+public final class ClassNameNoPackageTest {
+
   @Test public void shouldSupportClassInDefaultPackage() {
     ClassName className = ClassName.get(ClassNameNoPackageTest.class);
     assertThat(className.packageName()).isEqualTo("");

--- a/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
@@ -43,11 +43,11 @@ public class AnnotatedTypeNameTest {
   public @interface TypeUseAnnotation {}
 
 
-  @Test(expected=NullPointerException.class) public void nullAnnotationArray() {
+  @Test(expected = NullPointerException.class) public void nullAnnotationArray() {
     TypeName.BOOLEAN.annotated((AnnotationSpec[]) null);
   }
 
-  @Test(expected=NullPointerException.class) public void nullAnnotationList() {
+  @Test(expected = NullPointerException.class) public void nullAnnotationList() {
     TypeName.DOUBLE.annotated((List<AnnotationSpec>) null);
   }
 

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -377,7 +377,7 @@ public final class AnnotationSpecTest {
   @Test public void modifyMembers() {
     AnnotationSpec.Builder builder = AnnotationSpec.builder(SuppressWarnings.class)
             .addMember("value", "$S", "Foo");
-    
+
     builder.members.clear();
     builder.members.put("value", Arrays.asList(CodeBlock.of("$S", "Bar")));
 

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -110,16 +110,23 @@ public final class ClassNameTest {
     TypeElement object = elements.getTypeElement(Object.class.getCanonicalName());
     assertThat(ClassName.get(object).toString()).isEqualTo("java.lang.Object");
     TypeElement outer = elements.getTypeElement($Outer.class.getCanonicalName());
-    assertThat(ClassName.get(outer).toString()).isEqualTo("com.squareup.javapoet.ClassNameTest.$Outer");
-    TypeElement inner = elements.getTypeElement($Outer.$Inner.class.getCanonicalName());
-    assertThat(ClassName.get(inner).toString()).isEqualTo("com.squareup.javapoet.ClassNameTest.$Outer.$Inner");
+    assertThat(ClassName.get(outer).toString()).isEqualTo(
+      "com.squareup.javapoet.ClassNameTest.$Outer"
+    );
+    TypeElement inner = elements.getTypeElement(
+      $Outer.$Inner.class.getCanonicalName()
+    );
+    assertThat(ClassName.get(inner).toString()).isEqualTo(
+      "com.squareup.javapoet.ClassNameTest.$Outer.$Inner"
+    );
   }
 
   /**
    * Buck builds with "source-based ABI generation" and those builds don't support
    * {@link TypeElement#getKind()}. Test to confirm that we don't use that API.
    */
-  @Test @Ignore("Doesn't work with Java 17") public void classNameFromTypeElementDoesntUseGetKind() {
+  @Test @Ignore("Doesn't work with Java 17") public void
+      classNameFromTypeElementDoesntUseGetKind() {
     Elements elements = compilationRule.getElements();
     TypeElement object = elements.getTypeElement(Object.class.getCanonicalName());
     assertThat(ClassName.get(preventGetKind(object)).toString())
@@ -152,7 +159,9 @@ public final class ClassNameTest {
         .isEqualTo("com.squareup.javapoet.ClassNameTest.OuterClass.InnerClass");
     assertThat((ClassName.get(new Object() {}.getClass())).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest$1");
-    assertThat((ClassName.get(new Object() { Object inner = new Object() {}; }.inner.getClass())).toString())
+    assertThat((ClassName.get(new Object() {
+        Object inner = new Object() {};
+    }.inner.getClass())).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest$2$1");
     assertThat((ClassName.get($Outer.class)).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest.$Outer");

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -155,7 +155,7 @@ public final class CodeBlockTest {
       Map<String, Object> map = new LinkedHashMap<>();
       CodeBlock.builder().addNamed("$text:S", map).build();
       fail();
-    } catch(IllegalArgumentException expected) {
+    } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("Missing named argument for $text");
     }
   }
@@ -166,8 +166,10 @@ public final class CodeBlockTest {
       map.put("Text", "tacos");
       CodeBlock block = CodeBlock.builder().addNamed("$Text:S", map).build();
       fail();
-    } catch(IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("argument 'Text' must start with a lowercase character");
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "argument 'Text' must start with a lowercase character"
+      );
     }
   }
 
@@ -197,7 +199,7 @@ public final class CodeBlockTest {
     try {
       CodeBlock.builder().addNamed("$clazz:T$", map).build();
       fail();
-    } catch(IllegalArgumentException expected) {
+    } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("dangling $ at end");
     }
   }
@@ -207,7 +209,9 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$2T", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("index 2 for '$2T' not in range (received 1 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "index 2 for '$2T' not in range (received 1 arguments)"
+      );
     }
   }
 
@@ -216,7 +220,9 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$0T", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("index 0 for '$0T' not in range (received 1 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "index 0 for '$0T' not in range (received 1 arguments)"
+      );
     }
   }
 
@@ -252,7 +258,9 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1T").build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("index 1 for '$1T' not in range (received 0 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "index 1 for '$1T' not in range (received 0 arguments)"
+      );
     }
   }
 
@@ -288,7 +296,9 @@ public final class CodeBlockTest {
       codeBlock.toString();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("statement enter $[ followed by statement enter $[");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "statement enter $[ followed by statement enter $["
+      );
     }
   }
 
@@ -299,7 +309,9 @@ public final class CodeBlockTest {
       codeBlock.toString();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("statement exit $] has no matching statement enter $[");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "statement exit $] has no matching statement enter $["
+      );
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/CodeWriterTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeWriterTest.java
@@ -13,11 +13,11 @@ public class CodeWriterTest {
         CodeBlock javadocCodeBlock = CodeBlock.of("A\r\n\r\nB\r\n");
         StringBuilder out = new StringBuilder();
         new CodeWriter(out).emitJavadoc(javadocCodeBlock);
-        assertThat(out.toString()).isEqualTo(
-                "/**\n" +
-                        " * A\n" +
-                        " *\n" +
-                        " * B\n" +
-                        " */\n");
+        assertThat(out.toString()).isEqualTo(""
+            + "/**\n"
+            + " * A\n"
+            + " *\n"
+            + " * B\n"
+            + " */\n");
     }
 }

--- a/src/test/java/com/squareup/javapoet/FieldSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/FieldSpecTest.java
@@ -40,8 +40,7 @@ public class FieldSpecTest {
     try {
       FieldSpec.builder(int.class, "foo").addAnnotations(null);
       fail();
-    }
-    catch (IllegalArgumentException expected) {
+    } catch (IllegalArgumentException expected) {
       assertThat(expected.getMessage())
           .isEqualTo("annotationSpecs == null");
     }

--- a/src/test/java/com/squareup/javapoet/FileReadingTest.java
+++ b/src/test/java/com/squareup/javapoet/FileReadingTest.java
@@ -43,7 +43,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 @RunWith(JUnit4.class)
 public class FileReadingTest {
-  
+
   // Used for storing compilation output.
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -56,12 +56,12 @@ public class FileReadingTest {
     assertThat(JavaFile.builder("com.example", type).build().toJavaFileObject().toUri())
         .isEqualTo(URI.create("com/example/Test.java"));
   }
-  
+
   @Test public void javaFileObjectKind() {
     JavaFile javaFile = JavaFile.builder("", TypeSpec.classBuilder("Test").build()).build();
     assertThat(javaFile.toJavaFileObject().getKind()).isEqualTo(Kind.SOURCE);
   }
-  
+
   @Test public void javaFileObjectCharacterContent() throws IOException {
     TypeSpec type = TypeSpec.classBuilder("Test")
         .addJavadoc("Pi\u00f1ata\u00a1")
@@ -69,22 +69,22 @@ public class FileReadingTest {
         .build();
     JavaFile javaFile = JavaFile.builder("foo", type).build();
     JavaFileObject javaFileObject = javaFile.toJavaFileObject();
-    
+
     // We can never have encoding issues (everything is in process)
     assertThat(javaFileObject.getCharContent(true)).isEqualTo(javaFile.toString());
     assertThat(javaFileObject.getCharContent(false)).isEqualTo(javaFile.toString());
   }
-  
+
   @Test public void javaFileObjectInputStreamIsUtf8() throws IOException {
     JavaFile javaFile = JavaFile.builder("foo", TypeSpec.classBuilder("Test").build())
         .addFileComment("Pi\u00f1ata\u00a1")
         .build();
     byte[] bytes = ByteStreams.toByteArray(javaFile.toJavaFileObject().openInputStream());
-    
+
     // JavaPoet always uses UTF-8.
     assertThat(bytes).isEqualTo(javaFile.toString().getBytes(UTF_8));
   }
-  
+
   @Test public void compileJavaFile() throws Exception {
     final String value = "Hello World!";
     TypeSpec type = TypeSpec.classBuilder("Test")
@@ -100,17 +100,17 @@ public class FileReadingTest {
 
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
-    StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnosticCollector, 
+    StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnosticCollector,
         Locale.getDefault(), UTF_8);
     fileManager.setLocation(StandardLocation.CLASS_OUTPUT,
         Collections.singleton(temporaryFolder.newFolder()));
-    CompilationTask task = compiler.getTask(null, 
+    CompilationTask task = compiler.getTask(null,
         fileManager,
         diagnosticCollector,
         Collections.emptySet(),
         Collections.emptySet(),
         Collections.singleton(javaFile.toJavaFileObject()));
-    
+
     assertThat(task.call()).isTrue();
     assertThat(diagnosticCollector.getDiagnostics()).isEmpty();
 

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -307,7 +307,9 @@ public final class JavaFileTest {
 
   @Test
   public void recordTwoAnnotatedFields() {
-    AnnotationSpec annotationSpec = AnnotationSpec.builder(ClassName.get("com.squareup.tacos", "Spicy")).build();
+    AnnotationSpec annotationSpec = AnnotationSpec.builder(
+        ClassName.get("com.squareup.tacos", "Spicy")
+    ).build();
     String source = JavaFile
             .builder("com.squareup.tacos",
                     TypeSpec.recordBuilder("Taco")

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -154,7 +154,8 @@ public final class MethodSpecTest {
         + "@java.lang.Override\n"
         + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
         + "everything(\n"
-        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
+        + "    java.lang.String arg0, java.util.List<? extends T> arg1) "
+        + "throws java.io.IOException,\n"
         + "    java.lang.SecurityException {\n"
         + "}\n");
   }
@@ -237,38 +238,49 @@ public final class MethodSpecTest {
       MethodSpec.overriding(findFirst(methods, "finalMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "cannot override method with modifiers: [final]"
+      );
     }
     try {
       MethodSpec.overriding(findFirst(methods, "privateMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "cannot override method with modifiers: [private]"
+      );
     }
     try {
       MethodSpec.overriding(findFirst(methods, "staticMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "cannot override method with modifiers: [static]"
+      );
     }
   }
 
   abstract static class AbstractClassWithPrivateAnnotation {
 
-    private @interface PrivateAnnotation{ }
+    private @interface PrivateAnnotation {}
 
     abstract void foo(@PrivateAnnotation final String bar);
   }
 
   @Test public void overrideDoesNotCopyParameterAnnotations() {
     TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
-    ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
+    ExecutableElement fooElement = ElementFilter.methodsIn(
+      abstractTypeElement.getEnclosedElements()
+    ).get(0);
     ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");
     TypeSpec type = TypeSpec.classBuilder(implClassName)
             .superclass(abstractTypeElement.asType())
             .addMethod(MethodSpec.overriding(fooElement).build())
             .build();
-    JavaFileObject jfo = JavaFile.builder(implClassName.packageName, type).build().toJavaFileObject();
+    JavaFileObject jfo = JavaFile.builder(
+      implClassName.packageName,
+      type
+    ).build().toJavaFileObject();
     Compilation compilation = javac().compile(jfo);
     assertThat(compilation).succeeded();
   }
@@ -475,14 +487,14 @@ public final class MethodSpecTest {
         .build();
 
     assertThat(methodSpec.toString()).isEqualTo(""
-        + "void method() {\n" +
-        "  do {\n" +
-        "    valueField--;\n" +
-        "  } while (valueField > 5);\n" +
-        "}\n");
+        + "void method() {\n"
+        + "  do {\n"
+        + "    valueField--;\n"
+        + "  } while (valueField > 5);\n"
+        + "}\n");
   }
 
-  private static CodeBlock named(String format, Map<String, ?> args){
+  private static CodeBlock named(String format, Map<String, ?> args) {
     return CodeBlock.builder().addNamed(format, args).build();
   }
 

--- a/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
+++ b/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
@@ -81,7 +81,9 @@ public final class NameAllocatorTest {
       nameAllocator.newName("bar", 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("tag 1 cannot be used for both 'foo' and 'bar'");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "tag 1 cannot be used for both 'foo' and 'bar'"
+      );
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -31,7 +31,8 @@ import static org.junit.Assert.assertNotEquals;
 
 public class TypeNameTest {
 
-  private static final AnnotationSpec ANNOTATION_SPEC = AnnotationSpec.builder(ClassName.OBJECT).build();
+  private static final AnnotationSpec ANNOTATION_SPEC =
+    AnnotationSpec.builder(ClassName.OBJECT).build();
 
   protected <E extends Enum<E>> E generic(E[] values) {
     return values[0];

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -259,7 +259,8 @@ public final class TypeSpecTest {
         + "import java.lang.String;\n"
         + "\n"
         + "class Foo {\n"
-        + "  public Foo(long id, @Ping String one, @Ping String two, @Pong(\"pong\") String three,\n"
+        + "  public Foo(long id, @Ping String one, @Ping String two,"
+        + " @Pong(\"pong\") String three,\n"
         + "      @Ping String four) {\n"
         + "    /* code snippets */\n"
         + "  }\n"
@@ -2055,7 +2056,7 @@ public final class TypeSpecTest {
     try {
       TypeSpec.classBuilder("Taco").addModifiers((Modifier) null).build();
       fail();
-    } catch(IllegalArgumentException expected) {
+    } catch (IllegalArgumentException expected) {
       assertThat(expected.getMessage())
           .isEqualTo("modifiers contain null");
     }
@@ -2257,7 +2258,9 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$S");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("index 1 for '$S' not in range (received 0 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo(
+        "index 1 for '$S' not in range (received 0 arguments)"
+      );
     }
   }
 
@@ -2518,13 +2521,19 @@ public final class TypeSpecTest {
         + "import java.lang.String;\n"
         + "\n"
         + "class Taco {\n"
-        + "  void call(String s0, String s1, String s2, String s3, String s4, String s5, String s6, String s7,\n"
-        + "      String s8, String s9, String s10, String s11, String s12, String s13, String s14, String s15,\n"
-        + "      String s16, String s17, String s18, String s19, String s20, String s21, String s22,\n"
-        + "      String s23, String s24, String s25, String s26, String s27, String s28, String s29,\n"
+        + "  void call(String s0, String s1, String s2, String s3, String s4,"
+        + " String s5, String s6, String s7,\n"
+        + "      String s8, String s9, String s10, String s11, String s12,"
+        + " String s13, String s14, String s15,\n"
+        + "      String s16, String s17, String s18, String s19, String s20,"
+        + " String s21, String s22,\n"
+        + "      String s23, String s24, String s25, String s26, String s27,"
+        + " String s28, String s29,\n"
         + "      String s30, String s31) {\n"
-        + "    call(\"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\", \"10\", \"11\", \"12\", \"13\", \"14\", \"15\", \"16\",\n"
-        + "        \"17\", \"18\", \"19\", \"20\", \"21\", \"22\", \"23\", \"24\", \"25\", \"26\", \"27\", \"28\", \"29\", \"30\", \"31\");\n"
+        + "    call(\"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\", \"10\","
+        + " \"11\", \"12\", \"13\", \"14\", \"15\", \"16\",\n"
+        + "        \"17\", \"18\", \"19\", \"20\", \"21\", \"22\", \"23\", \"24\", \"25\", \"26\","
+        + " \"27\", \"28\", \"29\", \"30\", \"31\");\n"
         + "  }\n"
         + "}\n");
   }
@@ -2546,7 +2555,8 @@ public final class TypeSpecTest {
         + "class Taco {\n"
         + "  void call() {\n"
         + "    iAmSickOfWaitingInLine(\n"
-        + "        it, has, been, far, too, long, of, a, wait, and, i, would, like, to, eat, this, is, a, run, on, sentence);\n"
+        + "        it, has, been, far, too, long, of, a, wait, and, i, would,"
+        + " like, to, eat, this, is, a, run, on, sentence);\n"
         + "  }\n"
         + "}\n");
   }
@@ -2574,7 +2584,9 @@ public final class TypeSpecTest {
     ClassName className = ClassName.get("com.example", "Example");
     assertThat(TypeSpec.classBuilder(className).build().name).isEqualTo("Example");
     assertThat(TypeSpec.interfaceBuilder(className).build().name).isEqualTo("Example");
-    assertThat(TypeSpec.enumBuilder(className).addEnumConstant("A").build().name).isEqualTo("Example");
+    assertThat(
+      TypeSpec.enumBuilder(className).addEnumConstant("A").build().name
+    ).isEqualTo("Example");
     assertThat(TypeSpec.annotationBuilder(className).build().name).isEqualTo("Example");
   }
 
@@ -2665,7 +2677,7 @@ public final class TypeSpecTest {
     builder.originatingElements.clear();
     assertThat(builder.build().originatingElements).isEmpty();
   }
-    
+
   @Test public void javadocWithTrailingLineDoesNotAddAnother() {
     TypeSpec spec = TypeSpec.classBuilder("Taco")
         .addJavadoc("Some doc with a newline\n")

--- a/src/test/java/com/squareup/javapoet/TypesEclipseTest.java
+++ b/src/test/java/com/squareup/javapoet/TypesEclipseTest.java
@@ -53,6 +53,8 @@ public final class TypesEclipseTest extends AbstractTypesTest {
    *
    * <p>To use this rule in a test, just add the following field: <pre>   {@code
    *   @Rule public CompilationRule compilationRule = new CompilationRule();}
+   *  </pre>
+   * </p>
    *
    * @author Gregory Kick
    */
@@ -130,7 +132,11 @@ public final class TypesEclipseTest extends AbstractTypesTest {
       JavaCompiler compiler = new EclipseCompiler();
       DiagnosticCollector<JavaFileObject> diagnosticCollector =
           new DiagnosticCollector<>();
-      JavaFileManager fileManager = compiler.getStandardFileManager(diagnosticCollector, Locale.getDefault(), UTF_8);
+      JavaFileManager fileManager = compiler.getStandardFileManager(
+        diagnosticCollector,
+        Locale.getDefault(),
+        UTF_8
+      );
       JavaCompiler.CompilationTask task = compiler.getTask(
           null,
           fileManager,


### PR DESCRIPTION
Fixes #10

<h3>This PR adds value to the artifact in terms of code quality. It does not change the behaviour of the library whatsoever.</h3> 

The changes that were issued consist of:
- The reformatting of static code to comply with universal standards (that are derived from java sun).
- The addition of 1 dynamic and 1 static analysis tools to help with the future maintenance of the API:
  - **JaCoCo**: a codecov tool used for calculation of different types of test coverages (use `mvn jacoco:report` and see the output on target/site/jacoco). Right now, JaCoCo is configured to fail the build if the branch coverage is less than 80% or when there exists an untested class. If that configuration appears too restricting, it can be reconfigured accordingly (for example never fail a build, just output errors).
 
  - **CheckStyle**: a format-checker used to evalute if the codebase strays away from code formatting standards (use `mvn checkstyle:check` and see the output). Right now, checkstyle is configured with the rules in config/checkstyle/checkstyle.xml that are a (minor) mutation of the rules in the old artifact (JavaPoet). See commit for further details.