### PR TITLE
Optimize use of empty lists

### DIFF
--- a/src/main/java/com/squareup/javapoet/ArrayTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ArrayTypeName.java
@@ -21,7 +21,7 @@ import javax.lang.model.type.ArrayType;
 import java.io.IOException;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +32,7 @@ public final class ArrayTypeName extends TypeName {
   public final TypeName componentType;
 
   private ArrayTypeName(TypeName componentType) {
-    this(componentType, new ArrayList<>());
+    this(componentType, Collections.emptyList());
   }
 
   private ArrayTypeName(TypeName componentType, List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +35,7 @@ public final class ParameterizedTypeName extends TypeName {
 
   ParameterizedTypeName(ParameterizedTypeName enclosingType, ClassName rawType,
       List<TypeName> typeArguments) {
-    this(enclosingType, rawType, typeArguments, new ArrayList<>());
+    this(enclosingType, rawType, typeArguments, Collections.emptyList());
   }
 
   private ParameterizedTypeName(ParameterizedTypeName enclosingType, ClassName rawType,
@@ -61,7 +61,7 @@ public final class ParameterizedTypeName extends TypeName {
   @Override
   public TypeName withoutAnnotations() {
     return new ParameterizedTypeName(
-        enclosingType, rawType.withoutAnnotations(), typeArguments, new ArrayList<>());
+        enclosingType, rawType.withoutAnnotations(), typeArguments, Collections.emptyList());
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
@@ -95,8 +95,8 @@ public final class ParameterizedTypeName extends TypeName {
    */
   public ParameterizedTypeName nestedClass(String name) {
     checkNotNull(name, "name == null");
-    return new ParameterizedTypeName(this, rawType.nestedClass(name), new ArrayList<>(),
-        new ArrayList<>());
+    return new ParameterizedTypeName(this, rawType.nestedClass(name), Collections.emptyList(),
+        Collections.emptyList());
   }
 
   /**
@@ -106,7 +106,7 @@ public final class ParameterizedTypeName extends TypeName {
   public ParameterizedTypeName nestedClass(String name, List<TypeName> typeArguments) {
     checkNotNull(name, "name == null");
     return new ParameterizedTypeName(this, rawType.nestedClass(name), typeArguments,
-        new ArrayList<>());
+        Collections.emptyList());
   }
 
   /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -35,6 +35,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +97,7 @@ public class TypeName {
   private String cachedString;
 
   private TypeName(String keyword) {
-    this(keyword, new ArrayList<>());
+    this(keyword, Collections.emptyList());
   }
 
   private TypeName(String keyword, List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -36,7 +36,7 @@ public final class TypeVariableName extends TypeName {
   public final List<TypeName> bounds;
 
   private TypeVariableName(String name, List<TypeName> bounds) {
-    this(name, bounds, new ArrayList<>());
+    this(name, bounds, Collections.emptyList());
   }
 
   private TypeVariableName(String name, List<TypeName> bounds, List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -21,7 +21,6 @@ import javax.lang.model.type.TypeMirror;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +33,7 @@ public final class WildcardTypeName extends TypeName {
   public final List<TypeName> lowerBounds;
 
   private WildcardTypeName(List<TypeName> upperBounds, List<TypeName> lowerBounds) {
-    this(upperBounds, lowerBounds, new ArrayList<>());
+    this(upperBounds, lowerBounds, Collections.emptyList());
   }
 
   private WildcardTypeName(List<TypeName> upperBounds, List<TypeName> lowerBounds,


### PR DESCRIPTION
Closes #13 

This Pull Request replaces `new Arraylist<>()` with `Collections.emptyList()`, throughout the codebase, wherever empty immutable lists need to be used. Specifically this optimization was applied to the classes ArrayTypeName, TypeName, ParameterizedTypeName, TypeVariableName and WildCardTypeName. 

The implemented changes are in accordance with classes, such as ClassName, where `Collections.emptyList()` is already used in the same exact way.