### PR TITLE
fix infinite recursion bug on methodcall

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -610,7 +610,7 @@ public final class TypeSpec {
     public Builder addPermits(Iterable<? extends TypeName> permits) {
       checkArgument(permits != null, "permits == null");
       for (TypeName permit : permits) {
-        addPermits(permits);
+        addPermits(permit);
       }
       return this;
     }


### PR DESCRIPTION
Typo on TypeSpec method resulted in infinite recursion of addPermits() call.