### PR TITLE
Add Lambda support through Lambdaspec class

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -415,6 +415,11 @@ public final class CodeBlock {
       return this;
     }
 
+    public Builder addLambda(LambdaSpec lambda) {
+      add(lambda.toString());
+      return this;
+    }
+
     public Builder indent() {
       this.formatParts.add("$>");
       return this;

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -169,6 +169,10 @@ public final class FieldSpec {
       return this;
     }
 
+    public Builder initializer(LambdaSpec lambda) {
+      return initializer(lambda.toString());
+    }
+
     public FieldSpec build() {
       return new FieldSpec(this);
     }

--- a/src/main/java/com/squareup/javapoet/LambdaSpec.java
+++ b/src/main/java/com/squareup/javapoet/LambdaSpec.java
@@ -1,0 +1,234 @@
+package com.squareup.javapoet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Modifier;
+import static com.squareup.javapoet.Util.checkArgument;
+import static com.squareup.javapoet.Util.checkNotNull;;
+
+public class LambdaSpec {
+
+    /**
+     * The available format modes a lambda function can have.
+     * {@code VISIBLE_TYPES} example: (int x, int y) -> x + y;
+     * {@code BODY_NEWLINE} example:
+     * (x, y) ->
+     * x + y;
+     * {@code BODY_NEWLINE} + {@code BODY_INDENT} example:
+     * (x, y) -> {
+     *  int z = 3; return x + y + z;
+     * }
+    */
+    public enum LambdaMode {
+        VISIBLE_TYPES,
+        BODY_INDENT,
+        BODY_NEWLINE
+    }
+
+    /** The inputs of the function. */
+    private final List<ParameterSpec> inputs;
+
+    /** The body of the function. */
+    private final CodeBlock body;
+
+    /** @see LambdaSpec.LambdaMode LambdaMode.*/
+    public Set<LambdaMode> modes;
+
+    private LambdaSpec(Builder builder) {
+        this.inputs = checkNotNull(builder.inputs, "inputs == null");
+        validateInputs(this.inputs);
+        this.body = checkNotNull(builder.body, "body == null");
+        this.modes = checkNotNull(builder.modes, "modes == null");
+    }
+
+    /**
+     * Emits the left hand side of the lambda function, meaning
+     * the inputs.
+     * @param codeWriter the writer used to append the constructed
+     * inputs.
+     * @throws IOException
+     */
+    void emitInputs(CodeWriter codeWriter) throws IOException {
+        boolean emitTypes = false;
+
+        for (LambdaMode mode : this.modes) {
+            // handle all related modes the user specified.
+            // add cases when needed.
+            switch (mode) {
+                case VISIBLE_TYPES -> emitTypes = true;
+                default -> {continue;}
+            };
+        }
+
+        boolean placeParenthesis = inputs.size() > 1 || emitTypes || inputs.isEmpty();
+
+        codeWriter.emit(placeParenthesis ? "(" : "");
+
+        int paramsPlaced = 0;
+
+        // the inputs of the lambda (left side)
+        for (ParameterSpec inputParameter : inputs) {
+            if (emitTypes) {
+                codeWriter.emitAnnotations(inputParameter.annotations, true);
+                codeWriter.emitModifiers(inputParameter.modifiers);
+                codeWriter.emit(inputParameter.type.toString() + " ");
+            }
+            codeWriter.emit(inputParameter.name);
+            if (++paramsPlaced < inputs.size())
+                codeWriter.emit(", ");
+        }
+
+        codeWriter.emit(placeParenthesis ? ")" : "");
+    }
+
+    /**
+     * Emits the right hand side of the lambda function, meaning
+     * the body.
+     * @param codeWriter the writer used to append the constructed
+     * body.
+     * @throws IOException
+     */
+    void emitBody(CodeWriter codeWriter) throws IOException {
+        boolean indented = false;
+        boolean newLine = false;
+        for (LambdaMode mode : this.modes) {
+            // handle all related modes the user specified.
+            // add cases when needed.
+            switch (mode) {
+                case BODY_INDENT -> indented = true;
+                case BODY_NEWLINE -> newLine = true;
+                default -> {continue;}
+            }
+        }
+
+        String bodySide = this.body.toString();
+
+        // true if the function has more than 1 statement in its body
+        boolean multiStatementBody = bodySide.contains(";");
+
+        codeWriter.emit(multiStatementBody ? "{" : "");
+
+        codeWriter.emit(newLine ? "\n" : "");
+        if (indented) {
+            codeWriter.indent();
+            codeWriter.emit(body);
+            codeWriter.unindent();
+        } else {
+            codeWriter.emit(body);
+        }
+        codeWriter.emit(newLine ? "\n" : "");
+
+        codeWriter.emit(multiStatementBody ? "}" : "");
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (getClass() != o.getClass()) return false;
+        return toString().equals(o.toString());
+    }
+
+    @Override public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override public String toString() {
+        StringBuilder out = new StringBuilder();
+        try {
+            CodeWriter codeWriter = new CodeWriter(out);
+            emitInputs(codeWriter);
+            codeWriter.emit(" -> ");
+            emitBody(codeWriter);
+            return out.toString();
+        } catch (IOException e) {
+            throw new AssertionError();
+        }
+    }
+
+    /**
+     * Validates a list of parameters as lambda inputs.
+     * @param inputParameters the parameters of the lambda.
+     */
+    private static void validateInputs(List<ParameterSpec> inputParameters) {
+        for (ParameterSpec inputParameter : inputParameters) {
+            checkArgument(
+                !inputParameter.type.equals(TypeName.VOID),
+                "lambda input parameters cannot be of void type"
+            );
+            checkArgument(
+                inputParameter.modifiers.stream().allMatch(p -> p.equals(Modifier.FINAL)),
+                "lambda input parameters can only be final"
+            );
+        }
+    }
+
+    public static Builder builder(List<ParameterSpec> inputs, CodeBlock body) {
+        return new Builder(inputs, body);
+    }
+
+    public static Builder builder(List<ParameterSpec> inputs, String body) {
+        return builder(inputs, CodeBlock.of(body));
+    }
+
+    public static Builder builder(CodeBlock body) {
+        return new Builder(body);
+    }
+
+    public static Builder builder(String body) {
+        return builder(CodeBlock.of(body));
+    }
+
+    public Builder toBuilder() {
+        return toBuilder(inputs, body);
+    }
+
+    Builder toBuilder(List<ParameterSpec> inputs, CodeBlock body) {
+        Builder builder = new Builder(inputs, body);
+        builder.modes.addAll(modes);
+        return builder;
+    }
+
+    public static final class Builder {
+        public List<ParameterSpec> inputs = new ArrayList<>();
+        public CodeBlock body;
+        public Set<LambdaMode> modes = new LinkedHashSet<>();
+
+        private Builder(List<ParameterSpec> inputs, CodeBlock body) {
+            this.inputs = inputs;
+            this.body = body;
+        }
+
+        private Builder(List<ParameterSpec> inputs, String body) {
+            this(inputs, CodeBlock.of(body));
+        }
+
+        private Builder(CodeBlock body) {
+            this.body = body;
+        }
+
+        private Builder(String body) {
+            this(CodeBlock.of(body));
+        }
+
+        /** Adds an input to the function. */
+        public Builder addInput(ParameterSpec... parameters) {
+            Collections.addAll(this.inputs, parameters);
+            return this;
+        }
+
+        /** Adds a new format mode to the final lambda. */
+        public Builder addMode(LambdaMode... modes) {
+            Collections.addAll(this.modes, modes);
+            return this;
+        }
+
+        public LambdaSpec build() {
+            return new LambdaSpec(this);
+        }
+    }
+}

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -466,6 +466,11 @@ public final class MethodSpec {
       return this;
     }
 
+    public Builder addLambda(LambdaSpec lambda) {
+      code.addLambda(lambda);
+      return this;
+    }
+
     /**
      * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
      * Shouldn't contain braces or newline characters.

--- a/src/test/java/com/squareup/javapoet/LambdaSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/LambdaSpecTest.java
@@ -1,0 +1,128 @@
+package com.squareup.javapoet;
+
+import javax.lang.model.element.Modifier;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.squareup.javapoet.LambdaSpec.LambdaMode;
+
+public class LambdaSpecTest {
+
+    /** Ensure that void inputs result in exception. */
+    @Test public void ensureInputTypeError() {
+        // parameter with void type - should be rejected
+        ParameterSpec p1 = ParameterSpec.builder(TypeName.VOID, "x").build();
+
+        try {
+            // check that void type will cause errors
+            LambdaSpec.builder("2 * x").addInput(p1).build();
+
+            fail("Managed to create a lambda with void type input.");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo(
+                "lambda input parameters cannot be of void type"
+            );
+        }
+    }
+
+    /** Ensure that not all type inputs are allowed. */
+    @Test public void ensureInputModifierError() {
+        // parameter with modifier different than final - should be rejected
+        ParameterSpec p1 = ParameterSpec.builder(TypeName.INT, "x")
+            .addModifiers(Modifier.PUBLIC).build();
+
+        try {
+            // check that input will cause errors
+            LambdaSpec.builder("2 * x").addInput(p1).build();
+
+            fail("Managed to create a lambda with input of public access.");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo(
+                "lambda input parameters can only be final"
+            );
+        }
+    }
+
+    @Test public void ensureMethodSpecCompatibility() {
+        // lambda inputs
+        ParameterSpec p1 = ParameterSpec.builder(TypeName.INT, "x").build();
+        ParameterSpec p2 = ParameterSpec.builder(TypeName.DOUBLE, "y").build();
+    
+        // lambda body that considers input values
+        CodeBlock body1 = CodeBlock.of("int $3N = 3; return $1N + $2N + $3N;", "x", "y", "z");
+    
+        // lambda body that does not consider input values
+        CodeBlock body2 = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");
+
+        // lambdas of different nature
+        LambdaSpec lambda1 = LambdaSpec.builder(body1).addInput(p1, p2).addMode(LambdaMode.VISIBLE_TYPES).build();
+        LambdaSpec lambda2 = LambdaSpec.builder("x + y").addInput(p2).build();
+        LambdaSpec lambda3 = LambdaSpec.builder(body2).build();
+        LambdaSpec lambda4 = LambdaSpec.builder("5 + 7").build();
+        LambdaSpec lambda5 = LambdaSpec.builder("method1(); method2();").build();
+        LambdaSpec lambda6 = LambdaSpec.builder("x + 5").addInput(p1).addMode(LambdaMode.VISIBLE_TYPES).build();
+
+        MethodSpec method = MethodSpec.methodBuilder("method")
+        .addCode("methodCall(")
+        .addLambda(lambda1).addCode(", ") // lambda with multiple inputs and (CodeBlock) body and visible types
+        .addLambda(lambda2).addCode(", ") // lambda with single input and (String) body
+        .addLambda(lambda3).addCode(", ") // lambda with no inputs and (CodeBlock) body
+        .addLambda(lambda4).addCode(", ") // lambda with no inputs and (String) body
+        .addLambda(lambda5).addCode(", ") // lambda with multiple statements
+        .addLambda(lambda6).addCode(");\n") // lambda with single input of visible type
+        .build();
+
+        assertThat(method.toString()).isEqualTo(""
+          + "void method() {\n"
+          +  "  methodCall("
+          +    "(int x, double y) -> {int z = 3; return x + y + z;}, "
+          +    "y -> x + y, "
+          +    "() -> {int x = 3; int y = 5; return x + y;}, "
+          +    "() -> 5 + 7, "
+          +    "() -> {method1(); method2();}, "
+          +    "(int x) -> x + 5"
+          +  ");\n"
+          + "}\n"
+        );
+    }
+
+    @Test public void ensureCodeBlockCompatibility() {
+        // lambda body that does not consider input values
+        CodeBlock body = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");
+    
+        // lambda expression that does not consider input values
+        CodeBlock body2 = CodeBlock.of("5 + 3");
+    
+        LambdaSpec lambda1 = LambdaSpec.builder(body).build();
+        LambdaSpec lambda2 = LambdaSpec.builder(body2).build();
+        LambdaSpec lambda3 = LambdaSpec.builder(body).addMode(LambdaMode.BODY_NEWLINE, LambdaMode.BODY_INDENT).build();
+
+        CodeBlock codeWithLambda = CodeBlock.builder()
+        .add("methodCall(")
+        .addLambda(lambda1).add(", ") // producer lambda
+        .addLambda(lambda2).add(");\n")
+        .add("Producer<Integer> pr = ")
+        .addLambda(lambda3)
+        .build();
+    
+        MethodSpec method = MethodSpec.methodBuilder("method")
+        .addCode(codeWithLambda)
+        .build();
+
+        assertThat(method.toString()).isEqualTo(""
+          + "void method() {\n"
+          +  "  methodCall("
+          +  "() -> {int x = 3; int y = 5; return x + y;}, "
+          +   "() -> 5 + 3"
+          +  ");\n"
+          +  "  Producer<Integer> pr = () -> {\n"
+          +  "    int x = 3; int y = 5; return x + y;\n"
+          +  "  }\n"
+          + "}\n"
+        );
+    }
+    
+}

--- a/src/test/java/com/squareup/javapoet/LambdaSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/LambdaSpecTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import com.squareup.javapoet.LambdaSpec.LambdaMode;
 
 public class LambdaSpecTest {
 
@@ -50,20 +49,20 @@ public class LambdaSpecTest {
         // lambda inputs
         ParameterSpec p1 = ParameterSpec.builder(TypeName.INT, "x").build();
         ParameterSpec p2 = ParameterSpec.builder(TypeName.DOUBLE, "y").build();
-    
+
         // lambda body that considers input values
         CodeBlock body1 = CodeBlock.of("int $3N = 3; return $1N + $2N + $3N;", "x", "y", "z");
-    
+
         // lambda body that does not consider input values
         CodeBlock body2 = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");
 
         // lambdas of different nature
-        LambdaSpec lambda1 = LambdaSpec.builder(body1).addInput(p1, p2).addMode(LambdaMode.VISIBLE_TYPES).build();
+        LambdaSpec lambda1 = LambdaSpec.builder(body1).addInput(p1, p2).visibleTypes().build();
         LambdaSpec lambda2 = LambdaSpec.builder("x + y").addInput(p2).build();
         LambdaSpec lambda3 = LambdaSpec.builder(body2).build();
         LambdaSpec lambda4 = LambdaSpec.builder("5 + 7").build();
         LambdaSpec lambda5 = LambdaSpec.builder("method1(); method2();").build();
-        LambdaSpec lambda6 = LambdaSpec.builder("x + 5").addInput(p1).addMode(LambdaMode.VISIBLE_TYPES).build();
+        LambdaSpec lambda6 = LambdaSpec.builder("x + 5").addInput(p1).visibleTypes().build();
 
         MethodSpec method = MethodSpec.methodBuilder("method")
         .addCode("methodCall(")
@@ -92,13 +91,13 @@ public class LambdaSpecTest {
     @Test public void ensureCodeBlockCompatibility() {
         // lambda body that does not consider input values
         CodeBlock body = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");
-    
+
         // lambda expression that does not consider input values
         CodeBlock body2 = CodeBlock.of("5 + 3");
-    
+
         LambdaSpec lambda1 = LambdaSpec.builder(body).build();
         LambdaSpec lambda2 = LambdaSpec.builder(body2).build();
-        LambdaSpec lambda3 = LambdaSpec.builder(body).addMode(LambdaMode.BODY_NEWLINE, LambdaMode.BODY_INDENT).build();
+        LambdaSpec lambda3 = LambdaSpec.builder(body).beforeBody("\n  ").build();
 
         CodeBlock codeWithLambda = CodeBlock.builder()
         .add("methodCall(")
@@ -107,22 +106,21 @@ public class LambdaSpecTest {
         .add("Producer<Integer> pr = ")
         .addLambda(lambda3)
         .build();
-    
+
         MethodSpec method = MethodSpec.methodBuilder("method")
         .addCode(codeWithLambda)
         .build();
 
         assertThat(method.toString()).isEqualTo(""
-          + "void method() {\n"
-          +  "  methodCall("
-          +  "() -> {int x = 3; int y = 5; return x + y;}, "
-          +   "() -> 5 + 3"
-          +  ");\n"
-          +  "  Producer<Integer> pr = () -> {\n"
-          +  "    int x = 3; int y = 5; return x + y;\n"
-          +  "  }\n"
-          + "}\n"
-        );
+        + "void method() {\n"
+        +  "  methodCall("
+        +  "() -> {int x = 3; int y = 5; return x + y;}, "
+        +   "() -> 5 + 3"
+        +  ");\n"
+        +  "  Producer<Integer> pr = () ->\n"
+        +  "    {int x = 3; int y = 5; return x + y;}\n"
+        +  "}\n"
+      );
     }
-    
+
 }


### PR DESCRIPTION
First Part of #5 

This PR supplies the user with the ability to create lambdas and integrate them into his generated code, with the usage of the LambdaSpec class, which acts as a model of an anonymous function. A demonstration of the features' usage can be seen below.

The process of creating some simple lambda functions can be performed as such:
```
// lambdas with no inputs
LambdaSpec lambda1 = LambdaSpec.builder("5 + 7").build();
LambdaSpec lambda2 = LambdaSpec.builder("method1(); method2();").build();

// initialize some inputs
ParameterSpec p1 = ParameterSpec.builder(TypeName.INT, "x").build();
ParameterSpec p2 = ParameterSpec.builder(TypeName.DOUBLE, "y").build();

// lambda with inputs
LambdaSpec lambda3 = LambdaSpec.builder("x + y").addInput(p1, p2).build();
or (for the same result):
LambdaSpec lambda3 = LambdaSpec.builder(List.of(p1, p2), "x + y").build();

```
Now that the models are ready, they can be added in generated code:
```
MethodSpec method = MethodSpec.methodBuilder("method")
.addCode("methodCall(")
.addLambda(lambda1).addCode(", ")
.addLambda(lambda2).addCode(", ")
.addLambda(lambda3).addCode(");\n")
.build();
```
which results in:
```
void method() {
  methodCall(() -> 5 + 7, () -> {method1(); method2();}, (x, y) -> x + y);
}
```
They can be added to CodeBlocks the same way.
For further configuration of the output, such as formatting and optional visibility of components:
```
// body of the function
CodeBlock body = CodeBlock.of("int $1N = 3; int $2N = 5; return $1N + $2N;", "x", "y");

LambdaSpec lambda4 = LambdaSpec.builder(body).bodyOnNewLine().indentedBody().build();
```
Which is a model of:
```
() -> {
  int x = 3; int y = 5; return x + y;
}
```
While
```
LambdaSpec lambda5 = LambdaSpec.builder("x + 5").addInput(p1).visibleTypes().build();
```
is a model of:
```
(int x) -> x + 5
```
Further configuration (for example indents, new lines and spaces <b>inside</b> the body) can be done by the user though the CodeBlock methods, when creating said CodeBlock). In either case, more configuration types can be easily added and implemented with the help of the LambdaMode enum of the same class. Regarding the spaces between the ->, i left them unconfigurable due to the fact that their placement is a formatting standard (such as a space before the { in a for loop), just like other methods perform in the codebase, when placing similar unspecified spaces (for example beginControlFlow() of CodeBlock class). Here's what's specified in the Google Java Style Guide:
https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace